### PR TITLE
Correción variable local storage e introducción boton eliminar (elimina la variable del localstorage)

### DIFF
--- a/10Amatricesyarreglos.js
+++ b/10Amatricesyarreglos.js
@@ -4,6 +4,8 @@ let listaTareas=[];
 function iniciar(){
     let btonAgregar = document.getElementById("btnAgregar");
     btonAgregar.addEventListener("click",clickBtonAgregar);
+    let botonBorrarListaTareas = document.getElementById("btnBorrarLocalStorage");
+    botonBorrarListaTareas.addEventListener("click",clickBotonBorrarListaTareas);
     mostrarTareas();
 }
 
@@ -12,6 +14,14 @@ function clickBtonAgregar(){
     //La función getelementbyId me da el objeto, por eso si imprimimos esto por pantalla nos sacaría un [Object HTMLinputElement] en vez del valor.
     // Para que saque el valor habría que llamar a la propiedad "value" de este objeto ".value"
     let txt = document.getElementById("newTarea").value;
+    
+    //Metiendo este "if" he solucionado el error de que al reiniciar la web se borren las tareas del local storage
+    //porque se estaban sobreescribiendo/creando de nuevo. de esta manera si ya hay en el local storage, se
+    //meten de antemano en lista de tareas.
+    if (localStorage.tareasStorage!= undefined) {
+        listaTareas = JSON.parse(localStorage.tareasStorage);
+    }
+
     listaTareas.push(txt);
     //localStorage.setItem("Lista de tareas", JSON.stringify(listaTareas));
     //Como listaTareas es un objeto y no podemos guardar estos en el local storage,
@@ -27,7 +37,8 @@ function mostrarTareas(){
     let htmlString = "";
     
     // Verificar si localStorage.tareasStorage está definido y no es undefined
-    if (localStorage.tareasStorage!= undefined) {
+    //Igual que escribir != undefined, escribirlo de esta manera la condición del "if"
+    if (localStorage.tareasStorage) {
         let listaTareas = JSON.parse(localStorage.tareasStorage);
         for (let i = 0; i < listaTareas.length; i++) {
             htmlString += "Tarea " + (i + 1) + ": " + listaTareas[i] + "<br/>";
@@ -41,4 +52,8 @@ function mostrarTareas(){
     //let htmlFinalParse = JSON.stringify(htmlString);
     //htmlFinalParse = localStorage.getItem("Lista de tareas");
     para.innerHTML = htmlString;
+}
+
+function clickBotonBorrarListaTareas(){
+    localStorage.removeItem("tareasStorage");
 }

--- a/matricesyarreglos.html
+++ b/matricesyarreglos.html
@@ -15,7 +15,9 @@
     
     
     <div>
-        <h3>Listado:😊 </h3>
+        <h3>Listado 😊 </h3>
+        <button id="btnBorrarLocalStorage" type="button"> Eliminar Tareas</button>
+        <br></br>
         <div id="lista"></div>
     </div>
     


### PR DESCRIPTION
Aunque se guardaba correctamente en local storage y al actualizar la página no se borraba de la impresión de pantalla, al volver a meter una nueva tarea sí que se eliminaba. Esto era porque volvía a inicializar la variable del local storage con el vector de lista de tareas. Lo he solucionado cargándole a este vector el localstorage de antemano siempre que este exista (con un if). Si no se hiciera con un fin en la primera compilación daría error. 

Por otro lado, he introducido un botón que elimina esta variable del local storage y la resetea a cero tareas. 
<img width="379" alt="Screenshot 2024-03-21 at 14 54 33" src="https://github.com/m-mouchard/curso-javascript-experto/assets/69598389/7a964eac-d969-42f3-b61a-9be982af98ff">
